### PR TITLE
Remove internal from constructor

### DIFF
--- a/src/golem_source.sol
+++ b/src/golem_source.sol
@@ -232,7 +232,7 @@ contract GNTAllocation {
 
     uint256 tokensCreated = 0;
 
-    function GNTAllocation(address _golemFactory) internal {
+    function GNTAllocation(address _golemFactory) {
         gnt = GolemNetworkToken(msg.sender);
         unlockedAt = now + 6 * 30 days;
 


### PR DESCRIPTION
Starting with `solc 0.4.9` this fails to compile. Tested with `solc 0.4.10 commit 6bba106` and it still fails.

I think this is a safe change